### PR TITLE
PHP 8.3 compatibility - Make get_ipn_page_url explicitly static

### DIFF
--- a/CRM/Easyipn/Page/Easyipn.php
+++ b/CRM/Easyipn/Page/Easyipn.php
@@ -37,7 +37,7 @@ class CRM_Easyipn_Page_Easyipn extends CRM_Core_Page {
     parent::run();
   }
 
-  public function get_ipn_page_url($query = NULL) {
+  public static function get_ipn_page_url($query = NULL) {
     return CRM_Utils_System::url('civicrm/admin/setting/ipn-url', $query);
   }
 


### PR DESCRIPTION
On PHP 8.3, loading the Payment Processor listing page throws an error:

> Got error 'PHP message: PHP Fatal error:  Uncaught Error: Non-static method CRM_Easyipn_Page_Easyipn::get_ipn_page_url() cannot be called statically in /srv/www/SITE/public_html/wp-content/uploads/civicrm/ext/com.joineryhq.easyipn/easyipn.php:47

get_ipn_page_url() is only seems to ever be called line by 47 of easyipn.php, and as a static method:
```
$ipn_url = CRM_Easyipn_Page_Easyipn::get_ipn_page_url($args)
```

Defining it as a static method fixes PHP 8.3 compatibility.